### PR TITLE
refactor: implement active logic hooks 

### DIFF
--- a/src/drinx/attribute.py
+++ b/src/drinx/attribute.py
@@ -1,5 +1,9 @@
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 from dataclasses import field as orig_field, MISSING
+
+# Define constants for metadata key names to prevent hard-coded string erros
+DRINX_ON_SETATTR = "drinx_on_setattr"
+DRINX_ON_GETATTR = "drinx_on_getattr"
 
 
 def field(
@@ -13,6 +17,8 @@ def field(
     metadata: dict[str, Any] | None = None,
     kw_only: Any = MISSING,
     static: bool = False,
+    on_setattr: Sequence[Callable[..., Any]] = (),
+    on_getattr: Sequence[Callable[..., Any]] = (),
 ) -> Any:
     """Define a dataclass field with optional JAX static marking.
 
@@ -39,8 +45,10 @@ def field(
         A :class:`dataclasses.Field` descriptor (typed as ``Any`` for
         compatibility with type checkers).
     """
-    metadata = metadata or {}
+    metadata = dict(metadata or {})
     metadata["jax_static"] = static
+    metadata[DRINX_ON_SETATTR] = tuple(on_setattr)
+    metadata[DRINX_ON_GETATTR] = tuple(on_getattr)
 
     return orig_field(
         default=default,
@@ -64,6 +72,8 @@ def static_field(
     compare: bool = True,
     metadata: dict[str, Any] | None = None,
     kw_only: Any = MISSING,
+    on_setattr: Sequence[Callable[..., Any]] = (),
+    on_getattr: Sequence[Callable[..., Any]] = (),
 ) -> Any:
     """Define a JAX-static dataclass field.
 
@@ -95,6 +105,8 @@ def static_field(
         metadata=metadata,
         kw_only=kw_only,
         static=True,
+        on_setattr=on_setattr,
+        on_getattr=on_getattr,
     )
 
 
@@ -108,6 +120,8 @@ def private_field(
     metadata: dict[str, Any] | None = None,
     kw_only: Any = MISSING,
     static: bool = False,
+    on_setattr: Sequence[Callable[..., Any]] = (),
+    on_getattr: Sequence[Callable[..., Any]] = (),
 ) -> Any:
     """Define a private (non-init) dataclass field with optional JAX static marking.
 
@@ -139,6 +153,8 @@ def private_field(
         metadata=metadata,
         kw_only=kw_only,
         static=static,
+        on_setattr=on_setattr,
+        on_getattr=on_getattr,
     )
 
 
@@ -151,6 +167,8 @@ def static_private_field(
     compare: bool = True,
     metadata: dict[str, Any] | None = None,
     kw_only: Any = MISSING,
+    on_setattr: Sequence[Callable[..., Any]] = (),
+    on_getattr: Sequence[Callable[..., Any]] = (),
 ) -> Any:
     """Define a private (non-init), JAX-static dataclass field.
 
@@ -181,4 +199,6 @@ def static_private_field(
         metadata=metadata,
         kw_only=kw_only,
         static=True,
+        on_setattr=on_setattr,
+        on_getattr=on_getattr,
     )

--- a/src/drinx/base.py
+++ b/src/drinx/base.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
+from collections.abc import Sequence as ABCSequence
 import dataclasses
 import jax
 import jax.numpy as jnp
 from drinx.transform import dataclass
-from typing import dataclass_transform, Any, Generic, Self, TypeVar
+from typing import dataclass_transform, Any, Callable, Generic, Sequence, Self, TypeVar
 from dataclasses import field as orig_field
-from drinx.attribute import field, static_field, private_field, static_private_field
+from drinx.attribute import (
+    DRINX_ON_GETATTR,
+    DRINX_ON_SETATTR,
+    field,
+    private_field,
+    static_field,
+    static_private_field,
+)
 
 
 @dataclass_transform(
@@ -77,6 +85,14 @@ class DataClass:
                 compatibility).
         """
         super().__init_subclass__()
+        user_post_init = cls.__dict__.get("__post_init__")
+        if user_post_init is not None and user_post_init is not DataClass.__post_init__:
+            setattr(
+                cls,
+                "__post_init__",
+                DataClass._wrap_user_post_init(user_post_init),
+            )
+
         # Programmatically apply our custom dataclass wrapper to the subclass.
         dataclass_transform = dataclass(
             init=init,
@@ -89,6 +105,115 @@ class DataClass:
             weakref_slot=weakref_slot,
         )
         dataclass_transform(cls)
+        setattr(cls, "__setattr__", DataClass.__setattr__)
+        setattr(cls, "__getattribute__", DataClass.__getattribute__)
+
+    @staticmethod
+    def _wrap_user_post_init(
+        user_post_init: Callable[..., Any],
+    ) -> Callable[..., None]:
+        """Wraps the user-defined __post_init__ to ensure framework-level initialization logic runs afterward."""
+
+        def wrapped(self: DataClass, *args: Any, **kwargs: Any) -> None:
+            user_post_init(self, *args, **kwargs)
+            DataClass.__post_init__(self)
+
+        return wrapped
+
+    @staticmethod
+    def _normalize_callbacks(callbacks: Any) -> tuple[Callable[..., Any], ...]:
+        """Standardizes callback metadata into a consistent tuple of callable functions."""
+        if callbacks is None:
+            return ()
+        if isinstance(callbacks, ABCSequence) and not isinstance(
+            callbacks, (str, bytes)
+        ):
+            return tuple(callbacks)
+        return (callbacks,)
+
+    @staticmethod
+    def _run_callbacks(value: Any, callbacks: Sequence[Callable[..., Any]]) -> Any:
+        """Sequentially applies a series of callback functions to a value, passing the result of one to the next."""
+        result = value
+        for callback in callbacks:
+            callback_result = callback(result)
+            if callback_result is not None:
+                result = callback_result
+        return result
+
+    @staticmethod
+    def _get_field_definition(instance: DataClass, name: str) -> Any:
+        """Safely retrieves the dataclass field metadata for a specific attribute name using low-level access."""
+        try:
+            dataclass_fields = object.__getattribute__(instance, "__dataclass_fields__")
+        except AttributeError:
+            return None
+        return dataclass_fields.get(name)
+
+    def __post_init__(self) -> None:
+        """Executes initial field transformations and sets the initialization flag to lock the instance for immutability."""
+        object.__setattr__(self, "_drinx_initialized", False)
+        instance_dict = object.__getattribute__(self, "__dict__")
+        if instance_dict.get("_drinx_active_logic_applied", False):
+            object.__setattr__(self, "_drinx_initialized", True)
+            return
+        object.__setattr__(self, "_drinx_active_logic_applied", True)
+
+        for dc_field in dataclasses.fields(self):
+            try:
+                value = object.__getattribute__(self, dc_field.name)
+            except AttributeError:
+                continue
+            callbacks = DataClass._normalize_callbacks(
+                dc_field.metadata.get(DRINX_ON_SETATTR, ())
+            )
+            value = DataClass._run_callbacks(value, callbacks)
+            object.__setattr__(self, dc_field.name, value)
+        object.__setattr__(self, "_drinx_initialized", True)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Prevents modifications after initialization and applies setter callbacks during the initial phase."""
+        try:
+            is_initialized = object.__getattribute__(self, "_drinx_initialized")
+        except AttributeError:
+            is_initialized = False
+
+        if is_initialized:
+            raise dataclasses.FrozenInstanceError(f"cannot assign to field {name!r}")
+
+        dc_field = DataClass._get_field_definition(self, name)
+        if dc_field is None:
+            try:
+                instance_dict = object.__getattribute__(self, "__dict__")
+            except AttributeError:
+                instance_dict = {}
+            if name not in instance_dict and not hasattr(type(self), name):
+                raise AttributeError(
+                    f"{type(self).__name__!r} has no attribute {name!r}"
+                )
+            object.__setattr__(self, name, value)
+            return
+
+        callbacks = DataClass._normalize_callbacks(
+            dc_field.metadata.get(DRINX_ON_SETATTR, ())
+        )
+        value = DataClass._run_callbacks(value, callbacks)
+        object.__setattr__(self, name, value)
+
+    def __getattribute__(self, name: str) -> Any:
+        """Intercepts attribute access to apply getter callbacks for transformations like automatic unfreezing."""
+        value = object.__getattribute__(self, name)
+        if name.startswith("__") and name.endswith("__"):
+            return value
+
+        dc_field = DataClass._get_field_definition(self, name)
+        if dc_field is None:
+            return value
+
+        callbacks = DataClass._normalize_callbacks(
+            dc_field.metadata.get(DRINX_ON_GETATTR, ())
+        )
+        return DataClass._run_callbacks(value, callbacks)
 
     @staticmethod
     def _parse_operations(s: str) -> list[tuple[str | int, str]]:

--- a/src/drinx/base.py
+++ b/src/drinx/base.py
@@ -521,7 +521,7 @@ class DataClass:
             Self: A newly instantiated object with the updated attributes.
         """
         # Directly utilize dataclasses.replace for standard functional updates
-        return dataclasses.replace(self, **kwargs)  # ty:ignore[invalid-argument-type]
+        return dataclasses.replace(self, **kwargs)
 
 
 _DC = TypeVar("_DC", bound="DataClass")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -70,6 +70,50 @@ class TestBasicSubclassing:
 
 
 # ---------------------------------------------------------------------------
+# Active logic (on_setattr / on_getattr)
+# ---------------------------------------------------------------------------
+
+
+class TestActiveLogic:
+    def test_on_setattr_runs_in_post_init_for_default_values(self):
+        def none_to_default(value):
+            return "auto" if value is None else value
+
+        class Foo(DataClass):
+            name: str | None = field(default=None, on_setattr=(none_to_default,))
+
+        foo = Foo()
+        assert foo.name == "auto"
+
+    def test_on_setattr_runtime_assignment_is_frozen(self):
+        class Foo(DataClass):
+            name: str = field(on_setattr=(lambda v: v.strip().upper(),))
+
+        foo = Foo(name="  init  ")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            foo.name = "  runtime  "
+
+    def test_on_getattr_runs_on_runtime_access(self):
+        class Foo(DataClass):
+            x: int = field(default=2, on_getattr=(lambda v: v * 3,))
+
+        foo = Foo()
+        assert foo.x == 6
+
+    def test_user_post_init_is_preserved_and_callbacks_still_run(self):
+        class Foo(DataClass):
+            x: int = field(default=1, on_setattr=(lambda v: v + 1,))
+            y: int = private_field(default=0)
+
+            def __post_init__(self) -> None:
+                self.aset_inplace("y", 10)
+
+        foo = Foo()
+        assert foo.x == 2
+        assert foo.y == 10
+
+
+# ---------------------------------------------------------------------------
 # Always frozen
 # ---------------------------------------------------------------------------
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -198,7 +198,7 @@ class TestClassKeywordArgs:
             x: float
 
         with pytest.raises(TypeError):
-            Foo(x=1.0) < Foo(x=2.0)  # type: ignore[operator]
+            Foo(x=1.0) < Foo(x=2.0)  # ty:ignore[unsupported-operator]
 
     def test_eq_true_default(self):
         class Foo(DataClass):

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -3,6 +3,7 @@
 import dataclasses
 
 from drinx import field, private_field, static_field, static_private_field
+from drinx.attribute import DRINX_ON_GETATTR, DRINX_ON_SETATTR
 
 
 class TestField:
@@ -81,6 +82,20 @@ class TestField:
         assert f.default == 99
         assert f.metadata["jax_static"] is True
 
+    def test_on_setattr_metadata(self):
+        def callback(x):
+            return x
+
+        f = field(on_setattr=(callback,))
+        assert f.metadata[DRINX_ON_SETATTR] == (callback,)
+
+    def test_on_getattr_metadata(self):
+        def callback(x):
+            return x
+
+        f = field(on_getattr=(callback,))
+        assert f.metadata[DRINX_ON_GETATTR] == (callback,)
+
 
 class TestStaticField:
     def test_is_static(self):
@@ -121,6 +136,17 @@ class TestStaticField:
     def test_returns_dataclass_field(self):
         f = static_field()
         assert isinstance(f, dataclasses.Field)
+
+    def test_callbacks_are_forwarded(self):
+        def on_set(x):
+            return x
+
+        def on_get(x):
+            return x
+
+        f = static_field(on_setattr=(on_set,), on_getattr=(on_get,))
+        assert f.metadata[DRINX_ON_SETATTR] == (on_set,)
+        assert f.metadata[DRINX_ON_GETATTR] == (on_get,)
 
 
 class TestPrivateField:
@@ -164,6 +190,17 @@ class TestPrivateField:
         f = private_field(default=0)
         assert isinstance(f, dataclasses.Field)
 
+    def test_callbacks_are_forwarded(self):
+        def on_set(x):
+            return x
+
+        def on_get(x):
+            return x
+
+        f = private_field(default=0, on_setattr=(on_set,), on_getattr=(on_get,))
+        assert f.metadata[DRINX_ON_SETATTR] == (on_set,)
+        assert f.metadata[DRINX_ON_GETATTR] == (on_get,)
+
 
 class TestStaticPrivateField:
     def test_is_static(self):
@@ -202,3 +239,14 @@ class TestStaticPrivateField:
     def test_returns_dataclass_field(self):
         f = static_private_field(default=0)
         assert isinstance(f, dataclasses.Field)
+
+    def test_callbacks_are_forwarded(self):
+        def on_set(x):
+            return x
+
+        def on_get(x):
+            return x
+
+        f = static_private_field(default=0, on_setattr=(on_set,), on_getattr=(on_get,))
+        assert f.metadata[DRINX_ON_SETATTR] == (on_set,)
+        assert f.metadata[DRINX_ON_GETATTR] == (on_get,)

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -209,10 +209,12 @@ class TestVisualizeLeafTracers:
 
 class TestVisualizeLeafUnsupported:
     def test_string_returns_repr(self):
-        assert visualize_leaf("hello") == "'hello'"  # type: ignore[arg-type]
+        assert visualize_leaf("hello") == "'hello'"  # ty:ignore[invalid-argument-type]
 
     def test_list_returns_repr(self):
-        assert visualize_leaf([1, 2, 3]) == "[1, 2, 3]"  # type: ignore[arg-type]
+        assert (
+            visualize_leaf([1, 2, 3]) == "[1, 2, 3]"  # ty:ignore[invalid-argument-type]
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR implements on_setattr and on_getattr hook functionality for DataClass fields. Hooks and attribute changes are only allowed during the initialization stage. After the object is fully instantiated, static fields become strictly read-only (frozen).

In `fdtdx/objects/object.py`:
``` python 
@autoinit
class SimulationObject(TreeClass, ABC):
    ...
    name: str = frozen_field(  # type: ignore
        default=None,
        on_setattr=[UniqueName()],
    )
    ...
```
and now adopt the drinx library:
``` python 

class UniqueName(DataClass):
    def __call__(self, x: str | None) -> str:
        print("hello from uniquename")
        global _GLOBAL_COUNTER
        if x is None:
            name = f"Object_{_GLOBAL_COUNTER}"
            _GLOBAL_COUNTER += 1
            return name
        return x

class SimulationObject(DataClass, ABC):
    ...
    name: str = static_field(
        default=None,
        on_setattr=(UniqueName(),), 
    )
    ...
```