### PR TITLE
aset for private attributes

### DIFF
--- a/src/drinx/base.py
+++ b/src/drinx/base.py
@@ -497,7 +497,13 @@ class DataClass:
         assert cur_attr.__class__ == self.__class__
         return cur_attr
 
-    def aset_inplace(self, attr_name: str, val: Any) -> None:
+    def aset_inplace(
+        self,
+        attr_name: str,
+        val: Any,
+        create_new_ok: bool = False,
+        bypass_callbacks: bool = False,
+    ) -> None:
         """Sets an attribute of this dataclass **in place** by bypassing the frozen
         restriction via ``object.__setattr__``.
 
@@ -518,11 +524,45 @@ class DataClass:
         Args:
             attr_name: Path string (see :meth:`aset` for syntax).
             val: Value to assign at the target location.
+            create_new_ok (bool, optional): If False (default), raise if the target
+                attribute or dictionary key does not already exist.  If True, allow
+                setting new attributes or creating new dictionary keys.
+            bypass_callbacks (bool, optional): If True, skip ``on_setattr``
+                callbacks. If False, fire the callbacks registered on the target field before
+                writing, mirroring the behaviour of :meth:`aset` (default).
         """
         ops = self._parse_operations(attr_name)
         attr_list = self._traverse_path(ops)
         final_op, final_op_type = ops[-1]
         parent = attr_list[-1]
+
+        if final_op_type == "attribute":
+            if dataclasses.is_dataclass(parent):
+                dc_field_names = {f.name for f in dataclasses.fields(parent)}
+                if str(final_op) not in dc_field_names and not create_new_ok:
+                    raise Exception(
+                        f"Attribute: {final_op} does not exist for {parent.__class__}"
+                    )
+            elif not hasattr(parent, str(final_op)) and not create_new_ok:
+                raise Exception(
+                    f"Attribute: {final_op} does not exist for {parent.__class__}"
+                )
+        elif final_op_type == "key":
+            if not hasattr(parent, "__getitem__"):
+                raise Exception(f"{parent.__class__} does not implement __getitem__")
+            if final_op not in parent:
+                if not create_new_ok:
+                    raise Exception(f"Key: {final_op} does not exist for {parent}")
+
+        if final_op_type == "attribute" and not bypass_callbacks:
+            if dataclasses.is_dataclass(parent):
+                dc_fields = {f.name: f for f in dataclasses.fields(parent)}
+                target_field = dc_fields.get(str(final_op))
+                if target_field is not None:
+                    callbacks = DataClass._normalize_callbacks(
+                        target_field.metadata.get(DRINX_ON_SETATTR, ())
+                    )
+                    val = DataClass._run_callbacks(val, callbacks)
 
         if final_op_type == "attribute":
             object.__setattr__(parent, str(final_op), val)

--- a/src/drinx/base.py
+++ b/src/drinx/base.py
@@ -429,11 +429,16 @@ class DataClass:
 
         # Validate the final step (respecting create_new_ok)
         if final_op_type == "attribute":
-            if not hasattr(parent, str(final_op)):
-                if not create_new_ok:
+            if dataclasses.is_dataclass(parent):
+                dc_field_names = {f.name for f in dataclasses.fields(parent)}
+                if str(final_op) not in dc_field_names and not create_new_ok:
                     raise Exception(
                         f"Attribute: {final_op} does not exist for {parent.__class__}"
                     )
+            elif not hasattr(parent, str(final_op)) and not create_new_ok:
+                raise Exception(
+                    f"Attribute: {final_op} does not exist for {parent.__class__}"
+                )
         elif final_op_type == "index":
             if not hasattr(parent, "__getitem__"):
                 raise Exception(f"{parent.__class__} does not implement __getitem__")

--- a/src/drinx/base.py
+++ b/src/drinx/base.py
@@ -80,10 +80,14 @@ class DataClass:
             unsafe_hash: Force generation of ``__hash__`` even when ``eq=True``.
             match_args: Set ``__match_args__`` for structural pattern matching.
             kw_only: Make all fields keyword-only in ``__init__``.
-            slots: Generate ``__slots__`` (ignored; kept for API compatibility).
+            slots: Not supported; ignored.  Slot-based dataclasses are excluded
+                because ``__slots__`` attribute-access speedups are negligible
+                compared to JAX kernel dispatch overhead, and supporting them
+                would add significant complexity to pytree flatten/unflatten.
             weakref_slot: Add a ``__weakref__`` slot (ignored; kept for API
                 compatibility).
         """
+        del slots
         super().__init_subclass__()
         user_post_init = cls.__dict__.get("__post_init__")
         if user_post_init is not None and user_post_init is not DataClass.__post_init__:

--- a/src/drinx/base.py
+++ b/src/drinx/base.py
@@ -87,7 +87,7 @@ class DataClass:
             weakref_slot: Add a ``__weakref__`` slot (ignored; kept for API
                 compatibility).
         """
-        del slots
+        del slots, weakref_slot
         super().__init_subclass__()
         user_post_init = cls.__dict__.get("__post_init__")
         if user_post_init is not None and user_post_init is not DataClass.__post_init__:
@@ -106,7 +106,7 @@ class DataClass:
             unsafe_hash=unsafe_hash,
             match_args=match_args,
             kw_only=kw_only,
-            weakref_slot=weakref_slot,
+            weakref_slot=False,
         )
         dataclass_transform(cls)
         setattr(cls, "__setattr__", DataClass.__setattr__)

--- a/src/drinx/base.py
+++ b/src/drinx/base.py
@@ -374,11 +374,22 @@ class DataClass:
             attr_list.append(current_parent)
         return attr_list
 
+    @staticmethod
+    def _copy_and_set(obj: Any, field_name: str, value: Any) -> Any:
+        cls = type(obj)
+        new_obj = object.__new__(cls)
+        instance_dict = object.__getattribute__(obj, "__dict__")
+        for k, v in instance_dict.items():
+            object.__setattr__(new_obj, k, v)
+        object.__setattr__(new_obj, field_name, value)
+        return new_obj
+
     def aset(
         self,
         attr_name: str,
         val: Any,
         create_new_ok: bool = False,
+        allow_private: bool = False,
     ) -> Self:
         """Sets an attribute of this class. In contrast to the classical .at[].set(), this method updates the class
         attribute directly and does not only operate on jax pytree leaf nodes. Instead, replaces the full attribute
@@ -432,14 +443,23 @@ class DataClass:
             current_parent = attr_list[idx]
 
             if op_type == "attribute":
-                # Replaced generic DataClass check with standard dataclasses check
                 if not dataclasses.is_dataclass(current_parent):
                     raise Exception(
                         f"Can only set attribute functionally on a dataclass, but got {current_parent.__class__}"
                     )
 
-                # Use standard dataclasses.replace to functionally copy and update the frozen dataclass
-                cur_attr = dataclasses.replace(current_parent, **{str(op): cur_attr})
+                dc_fields = {f.name: f for f in dataclasses.fields(current_parent)}
+                target_field = dc_fields.get(str(op))
+                if target_field is None:
+                    raise TypeError(
+                        f"Field {str(op)!r} is not a dataclass field of {type(current_parent).__name__!r}."
+                    )
+                if not target_field.init and not allow_private:
+                    raise TypeError(
+                        f"Field {str(op)!r} has init=False (non-init/private field). "
+                        "Pass allow_private=True to allow updating non-init fields."
+                    )
+                cur_attr = DataClass._copy_and_set(current_parent, str(op), cur_attr)
 
             elif op_type in ("index", "key"):
                 if not hasattr(current_parent, "copy"):
@@ -537,7 +557,7 @@ class _AtIndexer(Generic[_DC]):
     def __getitem__(self, key: Any) -> "_AtIndexer[_DC]":
         return _AtIndexer(self._obj, self._path + [key])
 
-    def set(self, value: Any) -> _DC:
+    def set(self, value: Any, allow_private: bool = False) -> _DC:
         """Apply a functional update and return the new DataClass instance.
 
         If the accumulated path contains only ``str``/``int`` keys, delegates to
@@ -585,7 +605,7 @@ class _AtIndexer(Generic[_DC]):
                     "Expected str, int, or a DataClass mask."
                 )
         path_str = "->".join(parts)
-        return self._obj.aset(path_str, value)
+        return self._obj.aset(path_str, value, allow_private=allow_private)
 
 
 class _AtProxy(Generic[_DC]):

--- a/src/drinx/base.py
+++ b/src/drinx/base.py
@@ -390,6 +390,7 @@ class DataClass:
         val: Any,
         create_new_ok: bool = False,
         allow_private: bool = False,
+        bypass_callbacks: bool = False,
     ) -> Self:
         """Sets an attribute of this class. In contrast to the classical .at[].set(), this method updates the class
         attribute directly and does not only operate on jax pytree leaf nodes. Instead, replaces the full attribute
@@ -408,6 +409,9 @@ class DataClass:
             val (Any): Value to set the attribute to
             create_new_ok (bool, optional): If false (default), throw an error if the attribute does not exist.
                 If true, creates a new attribute if the attribute name does not exist yet.
+            bypass_callbacks (bool, optional): If True, skip ``on_setattr`` callbacks for all attribute
+                operations in the path. If False (default), each attribute write runs the callbacks
+                registered on that field, mirroring the behaviour of ``__setattr__`` during ``__init__``.
 
         Returns:
             Self: Updated instance with new attribute value
@@ -459,6 +463,11 @@ class DataClass:
                         f"Field {str(op)!r} has init=False (non-init/private field). "
                         "Pass allow_private=True to allow updating non-init fields."
                     )
+                if not bypass_callbacks:
+                    callbacks = DataClass._normalize_callbacks(
+                        target_field.metadata.get(DRINX_ON_SETATTR, ())
+                    )
+                    cur_attr = DataClass._run_callbacks(cur_attr, callbacks)
                 cur_attr = DataClass._copy_and_set(current_parent, str(op), cur_attr)
 
             elif op_type in ("index", "key"):
@@ -557,7 +566,9 @@ class _AtIndexer(Generic[_DC]):
     def __getitem__(self, key: Any) -> "_AtIndexer[_DC]":
         return _AtIndexer(self._obj, self._path + [key])
 
-    def set(self, value: Any, allow_private: bool = False) -> _DC:
+    def set(
+        self, value: Any, allow_private: bool = False, bypass_callbacks: bool = False
+    ) -> _DC:
         """Apply a functional update and return the new DataClass instance.
 
         If the accumulated path contains only ``str``/``int`` keys, delegates to
@@ -567,6 +578,7 @@ class _AtIndexer(Generic[_DC]):
         Args:
             value: The new value.  For mask updates this may be a scalar or a
                 DataClass tree of the same type as the mask/object.
+            bypass_callbacks: If True, skip ``on_setattr`` callbacks. Default False runs them.
 
         Returns:
             Updated DataClass instance.
@@ -605,7 +617,12 @@ class _AtIndexer(Generic[_DC]):
                     "Expected str, int, or a DataClass mask."
                 )
         path_str = "->".join(parts)
-        return self._obj.aset(path_str, value, allow_private=allow_private)
+        return self._obj.aset(
+            path_str,
+            value,
+            allow_private=allow_private,
+            bypass_callbacks=bypass_callbacks,
+        )
 
 
 class _AtProxy(Generic[_DC]):

--- a/src/drinx/transform.py
+++ b/src/drinx/transform.py
@@ -142,7 +142,10 @@ def dataclass(
         unsafe_hash: Force generation of ``__hash__`` even when ``eq=True``.
         match_args: Set ``__match_args__`` for structural pattern matching.
         kw_only: Make all fields keyword-only in ``__init__``.
-        slots: Generate ``__slots__``.
+        slots: Not supported.  Slot-based dataclasses are excluded because
+            ``__slots__`` attribute-access speedups are negligible compared to
+            JAX kernel dispatch overhead, and supporting them would add
+            significant complexity to pytree flatten/unflatten.
         weakref_slot: Add a ``__weakref__`` slot.
 
     Returns:

--- a/src/drinx/transform.py
+++ b/src/drinx/transform.py
@@ -19,11 +19,29 @@ def _register_jax_tree(cls_: type[T]) -> type[T]:
     dynamic_fields = [f.name for f in fields(cls_) if not f.metadata.get("jax_static")]
 
     def flatten_with_keys(obj):
-        keyed_leaves = [
-            (jax.tree_util.GetAttrKey(f), getattr(obj, f)) for f in dynamic_fields
-        ]
-        aux = tuple(getattr(obj, f) for f in static_fields)
-        return keyed_leaves, aux
+        keyed_leaves = []
+        for f in dynamic_fields:
+            try:
+                val = getattr(obj, f)
+            except AttributeError:
+                raise AttributeError(
+                    f"Field '{f}' of '{type(obj).__name__}' has not been set. "
+                    "Non-init fields must be assigned a default value or set in __post_init__."
+                ) from None
+            keyed_leaves.append((jax.tree_util.GetAttrKey(f), val))
+
+        aux = []
+        for f in static_fields:
+            try:
+                val = getattr(obj, f)
+            except AttributeError:
+                raise AttributeError(
+                    f"Field '{f}' of '{type(obj).__name__}' has not been set. "
+                    "Non-init fields must be assigned a default value or set in __post_init__."
+                ) from None
+            aux.append(val)
+
+        return keyed_leaves, tuple(aux)
 
     def unflatten(aux, leaves):
         kwargs = {**dict(zip(static_fields, aux)), **dict(zip(dynamic_fields, leaves))}

--- a/src/drinx/transform.py
+++ b/src/drinx/transform.py
@@ -156,6 +156,7 @@ def dataclass(
         ``frozen=True`` is always enforced and cannot be overridden.  Mutability
         would break JAX's pytree contract.
     """
+    del slots, weakref_slot
 
     # The wrapper handles the actual class modification
     def wrapper(cls_: type[T]) -> type[T]:
@@ -178,8 +179,8 @@ def dataclass(
             frozen=True,
             match_args=match_args,
             kw_only=kw_only,
-            slots=slots,
-            weakref_slot=weakref_slot,
+            slots=False,
+            weakref_slot=False,
         )
         cls_ = decorator(cls_)
         return _register_jax_tree(cls_)

--- a/src/drinx/visualize.py
+++ b/src/drinx/visualize.py
@@ -60,9 +60,7 @@ def visualize_leaf(val: int | float | complex | bool | np.ndarray | jax.Array) -
 
     # 2. Build compact dtype string (NumPy's dtype.kind already returns 'f', 'i', 'u', 'c', 'b')
     dtype_str = _dtype_str(dtype)
-    prefix = (
-        f"{dtype_str}[{','.join(map(str, shape))}]"  # ty:ignore[invalid-argument-type]
-    )
+    prefix = f"{dtype_str}[{','.join(map(str, shape))}]"
 
     # 3. Handle Tracers
     if is_traced(val):

--- a/src/drinx/visualize.py
+++ b/src/drinx/visualize.py
@@ -60,7 +60,7 @@ def visualize_leaf(val: int | float | complex | bool | np.ndarray | jax.Array) -
 
     # 2. Build compact dtype string (NumPy's dtype.kind already returns 'f', 'i', 'u', 'c', 'b')
     dtype_str = _dtype_str(dtype)
-    prefix = f"{dtype_str}[{','.join(map(str, shape))}]"
+    prefix = f"{dtype_str}[{','.join(str(d) for d in shape)}]"
 
     # 3. Handle Tracers
     if is_traced(val):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1521,6 +1521,22 @@ class TestAsetNonInitFields:
         assert updated.x in leaves
         assert updated._cache in leaves
 
+    def test_private_field_no_default(self):
+        """aset with allow_private=True must work for init=False fields that have no
+        default and were never set — so hasattr returns False but the field IS declared."""
+
+        class Foo(DataClass):
+            x: float
+            _derived: float = private_field()
+            # No __post_init__: _derived is absent from instance.__dict__
+
+        foo = Foo(x=3.0)  # ty:ignore[missing-argument]
+        # Before fix: raises "Attribute: _derived does not exist" because hasattr is False
+        # After fix: should return an updated copy with _derived set
+        updated = foo.aset("_derived", 99.0, allow_private=True)
+        assert updated._derived == pytest.approx(99.0)
+        assert updated.x == pytest.approx(3.0)
+
 
 # ---------------------------------------------------------------------------
 # aset method — nested DataClass attributes

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2028,3 +2028,170 @@ class TestAsetInplace:
 
         m = Model(weights=[1.0, 2.0, 3.0])  # ty:ignore[missing-argument]
         assert m.n_params == 3
+
+
+# ---------------------------------------------------------------------------
+# aset / .at[].set() callback behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestAsetCallbacks:
+    # --- A: bypass_callbacks=True skips callbacks ---
+
+    def test_bypass_true_skips_callback_public_field(self):
+        class Foo(DataClass):
+            x: int = field(default=1, on_setattr=(lambda v: v * 2,))
+
+        foo = Foo()
+        assert foo.x == 2  # init: 1 * 2 = 2
+        result = foo.aset("x", 3, bypass_callbacks=True)
+        assert result.x == 3  # callback bypassed, not 6
+
+    def test_bypass_true_skips_callback_private_field(self):
+        class Foo(DataClass):
+            x: int = field(default=0)
+            _computed: str = field(
+                init=False, default="", on_setattr=(lambda v: v.upper(),)
+            )
+
+        foo = Foo(x=1)
+        result = foo.aset(
+            "_computed", "hello", allow_private=True, bypass_callbacks=True
+        )
+        assert result._computed == "hello"  # callback bypassed, not "HELLO"
+
+    # --- B: bypass_callbacks=False (default) runs callbacks ---
+
+    def test_default_runs_callback_public_field(self):
+        class Foo(DataClass):
+            x: int = field(default=1, on_setattr=(lambda v: v * 2,))
+
+        foo = Foo()
+        result = foo.aset("x", 3)  # bypass_callbacks defaults to False
+        assert result.x == 6  # callback ran: 3 * 2 = 6
+
+    def test_bypass_false_runs_callback_public_field(self):
+        class Foo(DataClass):
+            x: int = field(default=1, on_setattr=(lambda v: v * 2,))
+
+        foo = Foo()
+        result = foo.aset("x", 3, bypass_callbacks=False)
+        assert result.x == 6
+
+    def test_bypass_false_runs_callback_private_field(self):
+        class Foo(DataClass):
+            x: int = field(default=0)
+            _raw: float = field(init=False, default=0.0, on_setattr=(lambda v: abs(v),))
+
+        foo = Foo(x=1)
+        result = foo.aset("_raw", -5.0, allow_private=True, bypass_callbacks=False)
+        assert result._raw == 5.0  # callback ran: abs(-5.0) = 5.0
+
+    def test_callback_chain_applied_in_order(self):
+        class Foo(DataClass):
+            x: int = field(default=0, on_setattr=(lambda v: v + 1, lambda v: v * 2))
+
+        foo = Foo(x=0)
+        result = foo.aset("x", 3, bypass_callbacks=False)
+        assert result.x == 8  # (3 + 1) * 2 = 8
+
+    def test_callback_returning_none_passes_value_through(self):
+        class Foo(DataClass):
+            x: int = field(default=0, on_setattr=(lambda v: None,))
+
+        foo = Foo(x=0)
+        result = foo.aset("x", 42, bypass_callbacks=False)
+        assert result.x == 42  # None return means pass-through
+
+    # --- C: Nested paths ---
+
+    def test_bypass_false_fires_leaf_callback_in_nested_path(self):
+        class Inner(DataClass):
+            w: int = field(default=0, on_setattr=(lambda v: v + 10,))
+
+        class Outer(DataClass):
+            inner: Inner
+
+        outer = Outer(inner=Inner(w=1))
+        assert outer.inner.w == 11  # init: 1 + 10 = 11
+        result = outer.aset("inner->w", 5, bypass_callbacks=False)
+        assert result.inner.w == 15  # callback ran: 5 + 10 = 15
+
+    def test_bypass_false_fires_intermediate_callback_in_nested_path(self):
+        class Inner(DataClass):
+            w: int
+
+        class Outer(DataClass):
+            inner: Inner = field(
+                default_factory=lambda: Inner(w=0),
+                on_setattr=(lambda v: type(v)(w=v.w * 2),),
+            )
+
+        outer = Outer(inner=Inner(w=3))
+        assert outer.inner.w == 6  # init: outer's callback doubled w: 3 * 2 = 6
+        result = outer.aset("inner->w", 5, bypass_callbacks=False)
+        # leaf step: no callback on w → new inner has w=5
+        # intermediate step: outer's inner callback fires → Inner(w=5*2=10)
+        assert result.inner.w == 10
+
+    def test_bypass_true_skips_all_callbacks_nested(self):
+        class Inner(DataClass):
+            w: int = field(default=0, on_setattr=(lambda v: v + 10,))
+
+        class Outer(DataClass):
+            inner: Inner
+
+        outer = Outer(inner=Inner(w=1))
+        result = outer.aset("inner->w", 5, bypass_callbacks=True)
+        assert result.inner.w == 5  # w's callback skipped
+
+    # --- D: .at[].set() delegation ---
+
+    def test_at_set_default_runs_callback(self):
+        class Foo(DataClass):
+            x: int = field(default=1, on_setattr=(lambda v: v * 2,))
+
+        foo = Foo()
+        result = foo.at["x"].set(3)
+        assert result.x == 6
+
+    def test_at_set_bypass_true_skips_callback(self):
+        class Foo(DataClass):
+            x: int = field(default=1, on_setattr=(lambda v: v * 2,))
+
+        foo = Foo()
+        result = foo.at["x"].set(3, bypass_callbacks=True)
+        assert result.x == 3
+
+    def test_at_set_private_field_runs_callback(self):
+        class Foo(DataClass):
+            x: int = field(default=0)
+            _raw: float = field(init=False, default=0.0, on_setattr=(lambda v: abs(v),))
+
+        foo = Foo(x=1)
+        result = foo.at["_raw"].set(-7.0, allow_private=True)
+        assert result._raw == 7.0
+
+    # --- E: aset_inplace does not run callbacks ---
+
+    def test_aset_inplace_does_not_run_callbacks(self):
+        class Foo(DataClass):
+            x: int = field(default=1, on_setattr=(lambda v: v * 2,))
+
+        foo = Foo()
+        assert foo.x == 2  # init: 1 * 2 = 2
+        # aset_inplace uses object.__setattr__ directly — callbacks never fire
+        foo.aset_inplace("x", 5)
+        assert foo.x == 5  # not 10: callback did not run
+
+    # --- F: original object unchanged ---
+
+    def test_original_unchanged_when_callbacks_run(self):
+        class Foo(DataClass):
+            x: int = field(default=3, on_setattr=(lambda v: v * 2,))
+
+        foo = Foo()
+        assert foo.x == 6  # init: 3 * 2 = 6
+        updated = foo.aset("x", 5, bypass_callbacks=False)
+        assert updated.x == 10  # 5 * 2 = 10
+        assert foo.x == 6  # original untouched

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2131,14 +2131,14 @@ class TestAsetInplaceCreateNewOk:
 
 
 class TestAsetInplaceBypassCallbacks:
-    def test_default_bypasses_callbacks(self):
+    def test_default_runs_callbacks(self):
         class Foo(DataClass):
             x: int = field(default=1, on_setattr=(lambda v: v * 2,))
 
         foo = Foo()
         assert foo.x == 2  # init ran callback: 1 * 2 = 2
         foo.aset_inplace("x", 5)
-        assert foo.x == 5  # default bypass_callbacks=True: callback not fired
+        assert foo.x == 10  # default bypass_callbacks=False: callback fires, 5 * 2 = 10
 
     def test_bypass_true_explicit_skips_callback(self):
         class Foo(DataClass):
@@ -2374,15 +2374,15 @@ class TestAsetCallbacks:
 
     # --- E: aset_inplace does not run callbacks ---
 
-    def test_aset_inplace_does_not_run_callbacks(self):
+    def test_aset_inplace_runs_callbacks_by_default(self):
         class Foo(DataClass):
             x: int = field(default=1, on_setattr=(lambda v: v * 2,))
 
         foo = Foo()
         assert foo.x == 2  # init: 1 * 2 = 2
-        # aset_inplace uses object.__setattr__ directly — callbacks never fire
+        # aset_inplace default bypass_callbacks=False — callbacks fire
         foo.aset_inplace("x", 5)
-        assert foo.x == 5  # not 10: callback did not run
+        assert foo.x == 10  # callback ran: 5 * 2 = 10
 
     # --- F: original object unchanged ---
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1362,7 +1362,7 @@ class TestAsetTopLevel:
 
     def test_nonexistent_attribute_create_new_ok_true_still_raises(self):
         # create_new_ok=True only skips the existence check on the walk-down;
-        # dataclasses.replace will still reject unknown fields.
+        # unknown fields are rejected because they are not registered dataclass fields.
         class Foo(DataClass):
             x: float
 
@@ -1398,7 +1398,7 @@ class TestAsetTopLevel:
         assert float(updated.x) == pytest.approx(42.0)
 
     def test_update_private_field_raises(self):
-        # dataclasses.replace() disallows init=False fields; private_field sets init=False
+        # allow_private defaults to False; non-init fields must be explicitly opted into
         class Foo(DataClass):
             x: float
             _cache: float = private_field(default=0.0)
@@ -1424,6 +1424,102 @@ class TestAsetTopLevel:
         leaves = jax.tree_util.tree_leaves(updated)
         assert 10.0 in leaves
         assert 2.0 in leaves
+
+
+# ---------------------------------------------------------------------------
+# aset method — non-init (private) fields (require allow_private=True)
+# ---------------------------------------------------------------------------
+
+
+class TestAsetNonInitFields:
+    def test_dynamic_private_field_direct(self):
+        class Foo(DataClass):
+            x: float
+            _cache: float = private_field(default=0.0)
+
+        foo = Foo(x=1.0)
+        updated = foo.aset("_cache", 5.0, allow_private=True)
+        assert updated._cache == 5.0
+        assert updated.x == 1.0
+
+    def test_static_private_field_direct(self):
+        class Foo(DataClass):
+            x: float
+            _static: int = static_private_field(default=0)
+
+        foo = Foo(x=1.0)
+        updated = foo.aset("_static", 99, allow_private=True)
+        assert updated._static == 99
+        assert updated.x == 1.0
+
+    def test_update_preserves_other_init_fields(self):
+        class Foo(DataClass):
+            x: float
+            y: float
+            _cache: float = private_field(default=0.0)
+
+        foo = Foo(x=1.0, y=2.0)
+        updated = foo.aset("_cache", 7.0, allow_private=True)
+        assert updated._cache == 7.0
+        assert updated.x == 1.0
+        assert updated.y == 2.0
+
+    def test_update_preserves_other_non_init_fields(self):
+        class Foo(DataClass):
+            x: float
+            _a: float = private_field(default=10.0)
+            _b: float = private_field(default=20.0)
+
+        foo = Foo(x=1.0)
+        updated = foo.aset("_a", 99.0, allow_private=True)
+        assert updated._a == 99.0
+        assert updated._b == 20.0
+
+    def test_nested_path_ending_at_private_field(self):
+        class Inner(DataClass):
+            w: float
+            _cache: float = private_field(default=0.0)
+
+        class Outer(DataClass):
+            inner: Inner
+            bias: float
+
+        outer = Outer(inner=Inner(w=1.0), bias=0.5)
+        updated = outer.aset("inner->_cache", 42.0, allow_private=True)
+        assert updated.inner._cache == 42.0
+        assert updated.inner.w == 1.0
+        assert updated.bias == 0.5
+
+    def test_at_proxy_with_private_field(self):
+        class Foo(DataClass):
+            x: float
+            _cache: float = private_field(default=0.0)
+
+        foo = Foo(x=1.0)
+        updated = foo.at["_cache"].set(5.0, allow_private=True)
+        assert updated._cache == 5.0
+        assert updated.x == 1.0
+
+    def test_private_field_with_default_factory(self):
+        class Foo(DataClass):
+            x: float
+            _items: list = private_field(default_factory=list)
+
+        foo = Foo(x=1.0)
+        updated = foo.aset("_items", [1, 2, 3], allow_private=True)
+        assert updated._items == [1, 2, 3]
+        assert updated.x == 1.0
+
+    def test_updated_result_is_valid_pytree(self):
+        class Foo(DataClass):
+            x: float
+            _cache: float = private_field(default=0.0)
+
+        foo = Foo(x=1.0)
+        updated = foo.aset("_cache", 5.0, allow_private=True)
+        leaves = jax.tree_util.tree_leaves(updated)
+        assert updated.x in leaves
+        assert updated._cache in leaves
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2031,6 +2031,206 @@ class TestAsetInplace:
 
 
 # ---------------------------------------------------------------------------
+# aset_inplace — create_new_ok
+# ---------------------------------------------------------------------------
+
+
+class TestAsetInplaceCreateNewOk:
+    def test_default_raises_on_missing_attribute(self):
+        class Foo(DataClass):
+            x: float
+
+        foo = Foo(x=1.0)
+        with pytest.raises(Exception, match="does not exist"):
+            foo.aset_inplace("nonexistent", 42.0)
+
+    def test_default_raises_on_missing_dict_key(self):
+        class Foo(DataClass):
+            data: dict
+
+        foo = Foo(data={"a": 1.0})
+        with pytest.raises(Exception, match="does not exist"):
+            foo.aset_inplace("data->['missing']", 99.0)
+
+    def test_create_new_ok_sets_new_attribute(self):
+        class Foo(DataClass):
+            x: float
+
+        foo = Foo(x=1.0)
+        foo.aset_inplace("brand_new", 7.0, create_new_ok=True)
+        assert foo.brand_new == 7.0  # type: ignore[attr-defined]
+
+    def test_create_new_ok_creates_new_dict_key(self):
+        class Foo(DataClass):
+            data: dict
+
+        foo = Foo(data={"a": 1.0})
+        foo.aset_inplace("data->['b']", 2.0, create_new_ok=True)
+        assert foo.data["b"] == 2.0
+        assert foo.data["a"] == 1.0
+
+    def test_existing_attribute_works_with_default(self):
+        class Foo(DataClass):
+            x: float
+
+        foo = Foo(x=1.0)
+        foo.aset_inplace("x", 5.0)
+        assert foo.x == 5.0
+
+    def test_existing_dict_key_works_with_default(self):
+        class Foo(DataClass):
+            data: dict
+
+        foo = Foo(data={"k": 0.0})
+        foo.aset_inplace("data->['k']", 9.0)
+        assert foo.data["k"] == 9.0
+
+    def test_list_index_unaffected_by_create_new_ok_false(self):
+        class Foo(DataClass):
+            items: list
+
+        foo = Foo(items=[1.0, 2.0])
+        foo.aset_inplace("items->[1]", 99.0)
+        assert foo.items[1] == 99.0
+
+    def test_list_index_unaffected_by_create_new_ok_true(self):
+        class Foo(DataClass):
+            items: list
+
+        foo = Foo(items=[1.0, 2.0])
+        foo.aset_inplace("items->[0]", 55.0, create_new_ok=True)
+        assert foo.items[0] == 55.0
+
+    def test_nested_path_missing_key_raises(self):
+        class Inner(DataClass):
+            data: dict
+
+        class Outer(DataClass):
+            inner: Inner
+
+        outer = Outer(inner=Inner(data={"a": 1.0}))
+        with pytest.raises(Exception, match="does not exist"):
+            outer.aset_inplace("inner->data->['missing']", 0.0)
+
+    def test_nested_path_missing_key_create_ok(self):
+        class Inner(DataClass):
+            data: dict
+
+        class Outer(DataClass):
+            inner: Inner
+
+        outer = Outer(inner=Inner(data={"a": 1.0}))
+        outer.aset_inplace("inner->data->['new_key']", 42.0, create_new_ok=True)
+        assert outer.inner.data["new_key"] == 42.0
+        assert outer.inner.data["a"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# aset_inplace — bypass_callbacks
+# ---------------------------------------------------------------------------
+
+
+class TestAsetInplaceBypassCallbacks:
+    def test_default_bypasses_callbacks(self):
+        class Foo(DataClass):
+            x: int = field(default=1, on_setattr=(lambda v: v * 2,))
+
+        foo = Foo()
+        assert foo.x == 2  # init ran callback: 1 * 2 = 2
+        foo.aset_inplace("x", 5)
+        assert foo.x == 5  # default bypass_callbacks=True: callback not fired
+
+    def test_bypass_true_explicit_skips_callback(self):
+        class Foo(DataClass):
+            x: int = field(default=1, on_setattr=(lambda v: v * 3,))
+
+        foo = Foo()
+        foo.aset_inplace("x", 4, bypass_callbacks=True)
+        assert foo.x == 4  # not 12
+
+    def test_bypass_false_runs_callback(self):
+        class Foo(DataClass):
+            x: int = field(default=1, on_setattr=(lambda v: v * 2,))
+
+        foo = Foo()
+        foo.aset_inplace("x", 5, bypass_callbacks=False)
+        assert foo.x == 10  # callback fired: 5 * 2 = 10
+
+    def test_bypass_false_no_callback_registered(self):
+        class Foo(DataClass):
+            x: float
+
+        foo = Foo(x=1.0)
+        foo.aset_inplace("x", 9.0, bypass_callbacks=False)
+        assert foo.x == 9.0  # no callback: value unchanged
+
+    def test_bypass_false_chained_callbacks(self):
+        class Foo(DataClass):
+            x: int = field(
+                default=1,
+                on_setattr=(lambda v: v + 1, lambda v: v * 3),
+            )
+
+        foo = Foo()
+        assert foo.x == 6  # init: (1+1)*3 = 6
+        foo.aset_inplace("x", 2, bypass_callbacks=False)
+        assert foo.x == 9  # (2+1)*3 = 9
+
+    def test_bypass_false_private_field(self):
+        """bypass_callbacks=False on an init=False field after initialization."""
+
+        class Foo(DataClass):
+            x: float
+            _derived: float = field(
+                init=False, default=0.0, on_setattr=(lambda v: v * 2,)
+            )
+
+        foo = Foo(x=5.0)
+        # DataClass.__post_init__ applied callback to default: 0.0 * 2 = 0.0
+        assert foo._derived == 0.0
+        foo.aset_inplace("_derived", 3.0, bypass_callbacks=False)
+        assert foo._derived == 6.0  # callback fired: 3.0 * 2 = 6.0
+
+    def test_bypass_false_index_op_no_callbacks(self):
+        """bypass_callbacks=False on a list index: no callbacks exist, value written as-is."""
+
+        class Foo(DataClass):
+            items: list
+
+        foo = Foo(items=[1.0, 2.0])
+        foo.aset_inplace("items->[0]", 77.0, bypass_callbacks=False)
+        assert foo.items[0] == 77.0
+
+    def test_bypass_false_dict_key_op_no_callbacks(self):
+        """bypass_callbacks=False on a dict key: no callbacks, value written as-is."""
+
+        class Foo(DataClass):
+            data: dict
+
+        foo = Foo(data={"k": 0.0})
+        foo.aset_inplace("data->['k']", 55.0, bypass_callbacks=False)
+        assert foo.data["k"] == 55.0
+
+    def test_create_new_ok_and_bypass_false_combined(self):
+        """create_new_ok=True and bypass_callbacks=False: new key created, callback fires on attr."""
+
+        class Foo(DataClass):
+            data: dict
+            x: int = field(default=1, on_setattr=(lambda v: v + 10,))
+
+        foo = Foo(data={})
+        # create new dict key — no callbacks apply to dict key ops
+        foo.aset_inplace(
+            "data->['fresh']", 3.0, create_new_ok=True, bypass_callbacks=False
+        )
+        assert foo.data["fresh"] == 3.0
+
+        # run callback on existing attribute
+        foo.aset_inplace("x", 5, bypass_callbacks=False)
+        assert foo.x == 15  # 5 + 10 = 15
+
+
+# ---------------------------------------------------------------------------
 # aset / .at[].set() callback behaviour
 # ---------------------------------------------------------------------------
 

--- a/tests/test_dataclass.py
+++ b/tests/test_dataclass.py
@@ -581,15 +581,6 @@ class TestStdField:
 
 
 class TestSlots:
-    def test_slots_true(self):
-        @dataclass(slots=True)
-        class Foo:
-            x: float
-
-        foo = Foo(x=1.0)
-        assert foo.x == 1.0
-        assert "__slots__" in dir(type(foo))
-
     def test_slots_false_by_default(self):
         @dataclass
         class Foo:


### PR DESCRIPTION
resolves #9 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added allow_private and bypass_callbacks controls for attribute updates.
  * Added create_new_ok to permit creating new attributes/keys during in-place updates.

* **Bug Fixes**
  * Clearer errors and stricter validation for missing or non-init fields; improved behavior for private-field updates.

* **Refactor**
  * Simplified visualization string formatting.

* **Documentation**
  * Documented that slot-based dataclasses are not supported.

* **Tests**
  * Expanded coverage for private-field updates, callback control, and create_new_ok.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->